### PR TITLE
refactor: use module alias

### DIFF
--- a/.nodemonrc
+++ b/.nodemonrc
@@ -1,5 +1,5 @@
 {
   "watch": ["src"],
   "ext": "ts,js,json",
-  "exec": "tsc -p . && node ."
+  "exec": "tsc -p . && npm start"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,7 +216,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -381,7 +380,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -441,7 +439,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -449,8 +446,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -642,8 +638,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "6.8.0",
@@ -1020,8 +1015,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "hosted-git-info": {
       "version": "2.8.5",
@@ -1348,6 +1342,14 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "link-module-alias": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/link-module-alias/-/link-module-alias-1.2.0.tgz",
+      "integrity": "sha512-ahPjXepbSVKbahTB6LxR//VHm8HPfI+QQygCH+E82spBY4HR5VPJTvlhKBc9F7muVxnS6C1rRfoPOXAbWO/fyw==",
+      "requires": {
+        "chalk": "^2.4.1"
+      }
     },
     "locate-path": {
       "version": "5.0.0",
@@ -2125,7 +2127,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "More details later",
   "main": "dist/index.js",
   "scripts": {
-    "start": "node .",
+    "start": "link-module-alias && node .",
     "dev": "nodemon --config .nodemonrc",
     "build": "tsc",
     "lint": "eslint . --ext .js,.ts",
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "dotenv": "^8.2.0",
+    "link-module-alias": "^1.2.0",
     "puppeteer": "^2.0.0"
   },
   "devDependencies": {
@@ -32,5 +33,8 @@
     "husky": "^3.1.0",
     "nodemon": "^2.0.2",
     "typescript": "^3.7.4"
+  },
+  "_moduleAliases": {
+    "~": "dist"
   }
 }

--- a/src/Scraper/Scraper.ts
+++ b/src/Scraper/Scraper.ts
@@ -1,11 +1,9 @@
 import puppeteer, { Browser } from "puppeteer";
-import { Codeforces, UVa, URI } from "../judges";
 import { IScraperOptions } from "./interfaces";
-import { IJudges } from "./interfaces";
 import { JUDGES } from "./constants";
 
 export default class Scraper {
-  private constructor(private browser: Browser) {}
+  private constructor(private browser: Browser) { }
 
   public static async run(options: IScraperOptions): Promise<Scraper> {
     const { headless = true, judges } = options;
@@ -17,7 +15,7 @@ export default class Scraper {
       const logins: Promise<void>[] = [];
 
       judges?.forEach(({ judge, credentials }) => {
-        const Judge: any = JUDGES[judge];
+        const Judge = JUDGES[judge];
         logins.push(new Judge(browser).login(credentials));
       });
 

--- a/src/Scraper/constants.ts
+++ b/src/Scraper/constants.ts
@@ -1,4 +1,4 @@
-import { Codeforces, UVa, URI } from "../judges";
+import { Codeforces, UVa, URI } from "~/judges";
 import { IJudges } from "./interfaces";
 
 export const JUDGES: IJudges = {

--- a/src/Scraper/interfaces.ts
+++ b/src/Scraper/interfaces.ts
@@ -1,4 +1,4 @@
-import { IJudgeOption, SupportedJudges } from "../judges";
+import { IJudgeOption, SupportedJudges } from "~/judges";
 
 export interface IScraperOptions {
   headless?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Scraper from "./Scraper";
+import Scraper from "~/Scraper";
 
 (async (): Promise<void> => {
   await Scraper.run({

--- a/src/judges/Codeforces/Codeforces.ts
+++ b/src/judges/Codeforces/Codeforces.ts
@@ -1,6 +1,6 @@
-import Judge from "../Judge";
-import { InvalidLoginCredentialsError } from "../../errors";
-import { IJudgeCredentials } from "../interfaces";
+import Judge from "~/judges/Judge";
+import { InvalidLoginCredentialsError } from "~/errors";
+import { IJudgeCredentials } from "~/judges/interfaces";
 
 class Codeforces extends Judge {
   async login(credentials: IJudgeCredentials): Promise<void> {

--- a/src/judges/URI/URI.ts
+++ b/src/judges/URI/URI.ts
@@ -1,6 +1,6 @@
-import Judge from "../Judge";
-import { InvalidLoginCredentialsError } from "../../errors";
-import { IJudgeCredentials } from "../interfaces";
+import Judge from "~/judges/Judge";
+import { InvalidLoginCredentialsError } from "~/errors";
+import { IJudgeCredentials } from "~/judges/interfaces";
 
 class URI extends Judge {
   async login(credentials: IJudgeCredentials): Promise<void> {

--- a/src/judges/UVa/UVa.ts
+++ b/src/judges/UVa/UVa.ts
@@ -1,5 +1,5 @@
-import Judge from "../Judge";
-import { IJudgeCredentials } from "../interfaces";
+import Judge from "~/judges/Judge";
+import { IJudgeCredentials } from "~/judges/interfaces";
 
 class UVa extends Judge {
   async login(credentials: IJudgeCredentials): Promise<void> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "resolveJsonModule": true,
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
module alias provides a better way for handling long relative import path hell

fixes #15

**NOTE**: files in the same directory should use the usual relative path import `./filename`