### PR TITLE
 refactor: use specifc data types

### DIFF
--- a/src/Scraper/Scraper.ts
+++ b/src/Scraper/Scraper.ts
@@ -15,7 +15,7 @@ export default class Scraper {
       const logins: Promise<void>[] = [];
 
       judges?.forEach(({ judge, credentials }) => {
-        const Judge: any = JUDGES[judge];
+        const Judge = JUDGES[judge];
         logins.push(new Judge(browser).login(credentials));
       });
 

--- a/src/Scraper/Scraper.ts
+++ b/src/Scraper/Scraper.ts
@@ -1,9 +1,9 @@
 import puppeteer, { Browser } from "puppeteer";
-import { IScraperOptions } from "./interfaces";
-import { JUDGES } from "./constants";
+import { IScraperOptions, JudgesObject } from "./interfaces";
+import { Codeforces, UVa, URI } from '../judges'
 
 export default class Scraper {
-  private constructor(private browser: Browser) {}
+  private constructor(private browser: Browser) { }
 
   public static async run(options: IScraperOptions): Promise<Scraper> {
     const { headless = true, judges } = options;
@@ -12,11 +12,15 @@ export default class Scraper {
       const browser = await puppeteer.launch({ headless });
       const scraper = new Scraper(browser);
 
-      const logins: Promise<void>[] = [];
+      const JUDGES: JudgesObject = {
+        Codeforces: new Codeforces(browser),
+        UVa: new UVa(browser),
+        URI: new URI(browser)
+      };
 
-      judges?.forEach(({ judge, credentials }) => {
+      const logins: Promise<void>[] = judges.map(({ judge, credentials }) => {
         const Judge = JUDGES[judge];
-        logins.push(new Judge(browser).login(credentials));
+        return Judge.login(credentials);
       });
 
       await Promise.all(logins);

--- a/src/Scraper/Scraper.ts
+++ b/src/Scraper/Scraper.ts
@@ -1,7 +1,5 @@
 import puppeteer, { Browser } from "puppeteer";
-import { Codeforces, UVa, URI } from "../judges";
 import { IScraperOptions } from "./interfaces";
-import { IJudges } from "./interfaces";
 import { JUDGES } from "./constants";
 
 export default class Scraper {

--- a/src/Scraper/constants.ts
+++ b/src/Scraper/constants.ts
@@ -1,8 +1,0 @@
-import { Codeforces, UVa, URI } from "../judges";
-import { IJudges } from "./interfaces";
-
-export const JUDGES: IJudges = {
-  Codeforces: Codeforces,
-  UVa: UVa,
-  URI: URI
-};

--- a/src/Scraper/interfaces.ts
+++ b/src/Scraper/interfaces.ts
@@ -1,10 +1,13 @@
-import { IJudgeOption, SupportedJudges } from "../judges";
+import { IJudgeOption, Codeforces, URI, UVa } from "../judges";
 
 export interface IScraperOptions {
   headless?: boolean;
-  judges?: IJudgeOption[];
+  judges: IJudgeOption[];
 }
 
-export type IJudges = {
-  [key in SupportedJudges]: any;
+export type JudgesObject = {
+  "Codeforces": Codeforces;
+  "URI": URI;
+  "UVa": UVa;
+  // [key in SupportedJudges]: Codeforces | URI | UVa;
 };


### PR DESCRIPTION
removed constants file and moved judges initiation to scraper.
made IScraperOptions::judges array required.
no more use of `any` type.

